### PR TITLE
Use factory methods and pass translate listener as a dependency

### DIFF
--- a/bounce/src/main/java/com/rahul/bounce/library/BounceTouchListener.java
+++ b/bounce/src/main/java/com/rahul/bounce/library/BounceTouchListener.java
@@ -3,6 +3,8 @@ package com.rahul.bounce.library;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
+import android.support.annotation.IdRes;
+import android.support.annotation.Nullable;
 import android.support.v4.view.MotionEventCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -32,18 +34,35 @@ public class BounceTouchListener implements View.OnTouchListener {
     private float mLastTouchY = -99;
     private int mMaxAbsTranslation = -99;
 
-    public BounceTouchListener(View mainScrollableView) {
-        this.mMainView = mainScrollableView;
-        this.mContent = this.mMainView;
+
+    private BounceTouchListener(View mainView, int contentResId, @Nullable OnTranslateListener listener) {
+        mMainView = mainView;
+        mContent = (contentResId == -1) ? mMainView : mMainView.findViewById(contentResId);
+        onTranslateListener = listener;
     }
 
-    public BounceTouchListener(View mainScrollableView, int contentResId) {
-        this.mMainView = mainScrollableView;
-        this.mContent = this.mMainView.findViewById(contentResId);
+    /**
+     * Creates a new BounceTouchListener
+     *
+     * @param mainScrollableView  The main view that this touch listener is attached to
+     * @param onTranslateListener To perform action on translation, can be null if not needed
+     * @return A new BounceTouchListener attached to the given scrollable view
+     */
+    public static BounceTouchListener create(View mainScrollableView, @Nullable OnTranslateListener onTranslateListener) {
+        return create(mainScrollableView, -1, onTranslateListener);
     }
 
-    public void setOnTranslateListener(OnTranslateListener onTranslateListener) {
-        this.onTranslateListener = onTranslateListener;
+    /**
+     * Creates a new BounceTouchListener
+     *
+     * @param mainView            The main view that this touch listener is attached to
+     * @param contentResId        Resource Id of the scrollable view
+     * @param onTranslateListener To perform action on translation, can be null if not needed
+     * @return A new BounceTouchListener attached to the given scrollable view
+     */
+    public static BounceTouchListener create(View mainView, @IdRes int contentResId,
+                                             @Nullable OnTranslateListener onTranslateListener) {
+        return new BounceTouchListener(mainView, contentResId, onTranslateListener);
     }
 
     @Override

--- a/example/src/main/java/com/rahul/bounce/ListViewFragment.java
+++ b/example/src/main/java/com/rahul/bounce/ListViewFragment.java
@@ -59,8 +59,7 @@ public class ListViewFragment extends Fragment implements AbsListView.OnScrollLi
         listView.setDivider(null);
         listView.setDividerHeight(0);
         listView.setOnScrollListener(this);
-        bounceTouchListener = new BounceTouchListener(listView);
-        bounceTouchListener.setOnTranslateListener(new BounceTouchListener.OnTranslateListener() {
+        bounceTouchListener = BounceTouchListener.create(listView, new BounceTouchListener.OnTranslateListener() {
             @Override
             public void onTranslate(float translation) {
                 if (translation > 0) {

--- a/example/src/main/java/com/rahul/bounce/MainActivity.java
+++ b/example/src/main/java/com/rahul/bounce/MainActivity.java
@@ -89,18 +89,19 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        BounceTouchListener bounceTouchListener = new BounceTouchListener(scrollView, R.id.splash_scroll_content);
-        bounceTouchListener.setOnTranslateListener(new BounceTouchListener.OnTranslateListener() {
-            @Override
-            public void onTranslate(float translation) {
-                if (translation > 0) {
-                    float scale = ((translation) / header.getLayoutParams().height) + 1;
-                    header.setScaleX(scale);
-                    header.setScaleY(scale);
+        BounceTouchListener bounceTouchListener = BounceTouchListener.create(scrollView, R.id.splash_scroll_content,
+                new BounceTouchListener.OnTranslateListener() {
+                    @Override
+                    public void onTranslate(float translation) {
+                        if (translation > 0) {
+                            float scale = ((translation) / header.getLayoutParams().height) + 1;
+                            header.setScaleX(scale);
+                            header.setScaleY(scale);
 
+                        }
+                    }
                 }
-            }
-        });
+        );
 
         scrollView.setOnTouchListener(bounceTouchListener);
 

--- a/example/src/main/java/com/rahul/bounce/RecyclerViewFragment.java
+++ b/example/src/main/java/com/rahul/bounce/RecyclerViewFragment.java
@@ -81,8 +81,7 @@ public class RecyclerViewFragment extends Fragment {
         recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
         recyclerView.setPivotX(Utils.getScreenWidth(getActivity()));
         recyclerView.addOnScrollListener(onScrollListener);
-        bounceTouchListener = new BounceTouchListener(recyclerView);
-        bounceTouchListener.setOnTranslateListener(new BounceTouchListener.OnTranslateListener() {
+        bounceTouchListener = BounceTouchListener.create(recyclerView, new BounceTouchListener.OnTranslateListener() {
             @Override
             public void onTranslate(float translation) {
                 if (translation > 0) {

--- a/example/src/main/java/com/rahul/bounce/ScrollViewFragment.java
+++ b/example/src/main/java/com/rahul/bounce/ScrollViewFragment.java
@@ -40,21 +40,20 @@ public class ScrollViewFragment extends Fragment {
 
         header = root.findViewById(R.id.header_image_view);
         scrollView = (ScrollView) root.findViewById(R.id.scroll_view);
-        BounceTouchListener bounceTouchListener = new BounceTouchListener(scrollView, R.id.content);
-        bounceTouchListener.setOnTranslateListener(new BounceTouchListener.OnTranslateListener() {
-            @Override
-            public void onTranslate(float translation) {
-                if (translation > 0) {
-                    float scale = ((2 * translation) / header.getMeasuredHeight()) + 1;
-                    header.setScaleX(scale);
-                    header.setScaleY(scale);
+        BounceTouchListener bounceTouchListener = BounceTouchListener.create(scrollView, R.id.content,
+                new BounceTouchListener.OnTranslateListener() {
+                    @Override
+                    public void onTranslate(float translation) {
+                        if (translation > 0) {
+                            float scale = ((2 * translation) / header.getMeasuredHeight()) + 1;
+                            header.setScaleX(scale);
+                            header.setScaleY(scale);
+                        }
+                    }
                 }
-            }
-        });
-
+        );
 
         scrollView.setOnTouchListener(bounceTouchListener);
-
         return root;
     }
 


### PR DESCRIPTION
This entails an api change, but following are my points in favor of this change:

* It is inherently clear that bounce library has a dependency on the touch listener.
* A use case without a translate listener is very limited 
* This change supports the no translate use case since Bounce can handle no translate listener anyway.
